### PR TITLE
Hw5

### DIFF
--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -61,6 +61,22 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
+      <!-- Mockito Core (for unit tests) -->
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>5.7.0</version>
+        <scope>test</scope>
+      </dependency>
+
+      <!-- Mockito JUnit 5 Extension (if using JUnit 5) -->
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-junit-jupiter</artifactId>
+        <version>5.7.0</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/h2/src/main/org/h2/command/query/Optimizer.java
+++ b/h2/src/main/org/h2/command/query/Optimizer.java
@@ -13,6 +13,7 @@ import org.h2.table.Plan;
 import org.h2.table.PlanItem;
 import org.h2.table.TableFilter;
 import org.h2.util.Permutations;
+import org.h2.command.query.RuleBasedJoinOrderPicker;
 
 /**
  * The optimizer is responsible to find the best execution plan
@@ -82,7 +83,9 @@ class Optimizer {
         } else {
             startNs = System.nanoTime();
             if (filters.length <= MAX_BRUTE_FORCE_FILTERS) {
-                calculateBruteForceAll(isSelectCommand);
+                RuleBasedJoinOrderPicker ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(session, filters);
+                TableFilter[] ruleBasedResult = ruleBasedJoinOrderPicker.bestOrder();
+                testPlan(ruleBasedResult, isSelectCommand);
             } else {
                 calculateBruteForceSome(isSelectCommand);
                 random = new Random(0);
@@ -110,10 +113,6 @@ class Optimizer {
 
         p.next();
         testPlan(list, isSelectCommand);
-
-//        for (int x = 0; !canStop(x) && p.next(); x++) {
-//            testPlan(list, isSelectCommand);
-//        }
     }
 
     private void calculateBruteForceSome(boolean isSelectCommand) {

--- a/h2/src/main/org/h2/command/query/RuleBasedJoinOrderPicker.java
+++ b/h2/src/main/org/h2/command/query/RuleBasedJoinOrderPicker.java
@@ -1,0 +1,104 @@
+package org.h2.command.query;
+
+import org.h2.engine.SessionLocal;
+import org.h2.table.TableFilter;
+import org.h2.table.Table;
+
+/**
+ * Determines the best join order by following rules rather than considering every possible permutation.
+ */
+public class RuleBasedJoinOrderPicker {
+    final SessionLocal session;
+    final TableFilter[] filters;
+
+    public RuleBasedJoinOrderPicker(SessionLocal session, TableFilter[] filters) {
+        this.session = session;
+        this.filters = filters;
+    }
+
+    public TableFilter[] bestOrder() {
+        List<TableFilter> ordered = new ArrayList<>();
+        List<TableFilter> remaining = new ArrayList<>(Arrays.asList(filters));
+
+        // Step 1: Select the first table, i.e., the one with the lowest row count.
+        TableFilter first = null;
+        long minRowCount = Long.MAX_VALUE;
+        for (TableFilter f : remaining) {
+            long rowCount = getRowCount(f);
+            if (rowCount < minRowCount) {
+                minRowCount = rowCount;
+                first = f;
+            }
+        }
+        if (first == null) {
+            // Should not occur, but if it does, return the original order.
+            return filters;
+        }
+        ordered.add(first);
+        remaining.remove(first);
+
+        // Step 2: Iteratively add the remaining tables.
+        // a) Prefer tables that have an explicit join condition with any already ordered table.
+        // b) Among those, choose the one with the lowest row count.
+        while (!remaining.isEmpty()) {
+            TableFilter candidate = null;
+            minRowCount = Long.MAX_VALUE;
+            for (TableFilter f : remaining) {
+                if (hasExplicitJoinCondition(f, ordered)) {
+                    long rowCount = getRowCount(f);
+                    if (rowCount < minRowCount) {
+                        minRowCount = rowCount;
+                        candidate = f;
+                    }
+                }
+            }
+            // If no table meets the join condition requirement, choose the one with the lowest row count.
+            if (candidate == null) {
+                for (TableFilter f : remaining) {
+                    long rowCount = getRowCount(f);
+                    if (rowCount < minRowCount) {
+                        minRowCount = rowCount;
+                        candidate = f;
+                    }
+                }
+            }
+            ordered.add(candidate);
+            remaining.remove(candidate);
+        }
+        return ordered.toArray(new TableFilter[ordered.size()]);
+    }
+
+    /**
+     * Retrieves the approximate row count for a given TableFilter.
+     * First, it attempts to call getRowCountApproximation() on the filter.
+     * If that method does not exist, it falls back to the underlying table's method.
+     */
+    private long getRowCount(TableFilter filter) {
+        try {
+            return filter.getRowCountApproximation();
+        } catch (NoSuchMethodError e) {
+            return filter.getTable().getRowCountApproximation();
+        }
+    }
+
+    /**
+     * Determines whether the given TableFilter has an explicit join condition with any of
+     * the tables in the ordered list. It does this by retrieving the full join condition
+     * expression, converting it to SQL, and checking if it contains any alias from the ordered tables.
+     */
+    private boolean hasExplicitJoinCondition(TableFilter filter, List<TableFilter> ordered) {
+        Expression expr = filter.getFullCondition();
+        if (expr == null) {
+            return false;
+        }
+        String condSql = expr.getSQL();
+        for (TableFilter t : ordered) {
+            // Use getTableAlias() to obtain the table alias (or table name if no alias is set)
+            if (condSql.contains(t.getTableAlias())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -1292,4 +1292,8 @@ public class TableFilter implements ColumnResolver {
         }
     }
 
+    public Expression getFullCondition(){
+        return fullCondition;
+    }
+
 }

--- a/h2/src/test/org/h2/command/query/RuleBasedJoinOrderPickerTest.java
+++ b/h2/src/test/org/h2/command/query/RuleBasedJoinOrderPickerTest.java
@@ -1,0 +1,215 @@
+package org.h2.command.query;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.h2.engine.Database;
+import org.h2.engine.SessionLocal;
+import org.h2.expression.Expression;
+import org.h2.expression.ExpressionColumn;
+import org.h2.expression.condition.BooleanTest;
+import org.h2.expression.condition.Comparison;
+import org.h2.expression.condition.ConditionAndOr;
+import org.h2.expression.condition.ConditionAndOrN;
+import org.h2.table.Table;
+import org.h2.table.TableFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class RuleBasedJoinOrderPickerTest {
+    SessionLocal mockSession;
+    Database mockDatabase;
+
+    RuleBasedJoinOrderPicker ruleBasedJoinOrderPicker;
+
+    Table customersTable;
+    Table locationsTable;
+    Table ordersTable;
+    Table orderLinesTable;
+
+    ExpressionColumn locationsLocationId;
+
+    ExpressionColumn customersCustomerId;
+    ExpressionColumn customersLocationId;
+
+    ExpressionColumn ordersOrderId;
+    ExpressionColumn ordersLocationId;
+    ExpressionColumn ordersCustomerId;
+
+    ExpressionColumn orderLinesOrderLineId;
+    ExpressionColumn orderLinesOrderId;
+    ExpressionColumn orderLinesLocationId;
+    ExpressionColumn orderLinesCustomerId;
+
+    @BeforeEach
+    public void setUp(){
+        mockSession = Mockito.mock(SessionLocal.class);
+        Mockito.when(mockSession.nextObjectId()).thenReturn(1);
+
+        mockDatabase = Mockito.mock(Database.class);
+
+        // for the purposes of this unit test, we will use four mock tables with
+        // multiple relationships between them
+        locationsTable = Mockito.mock(Table.class);
+        Mockito.when(locationsTable.getName()).thenReturn("locations");
+        Mockito.when(locationsTable.getRowCountApproximation(mockSession)).thenReturn(15L);
+
+        customersTable = Mockito.mock(Table.class);
+        Mockito.when(customersTable.getName()).thenReturn("customers");
+        Mockito.when(customersTable.getRowCountApproximation(mockSession)).thenReturn(50L);
+
+        ordersTable = Mockito.mock(Table.class);
+        Mockito.when(ordersTable.getName()).thenReturn("orders");
+        Mockito.when(ordersTable.getRowCountApproximation(mockSession)).thenReturn(1000L);
+
+        orderLinesTable = Mockito.mock(Table.class);
+        Mockito.when(orderLinesTable.getName()).thenReturn("orderLines");
+        Mockito.when(orderLinesTable.getRowCountApproximation(mockSession)).thenReturn(5000L);
+
+        // locations (15 rows)
+        //  -> location_id
+        locationsLocationId = Mockito.mock(ExpressionColumn.class);
+        Mockito.when(locationsLocationId.getTableName()).thenReturn("locations");
+        // customers (50 rows)
+        //  -> location_id
+        customersCustomerId = Mockito.mock(ExpressionColumn.class);
+        customersLocationId = Mockito.mock(ExpressionColumn.class);
+        Mockito.when(customersCustomerId.getTableName()).thenReturn("customers");
+        Mockito.when(customersLocationId.getTableName()).thenReturn("customers");
+        // orders (1,000 rows)
+        //  -> location_id
+        //  -> customer_id
+        ordersOrderId = Mockito.mock(ExpressionColumn.class);
+        ordersLocationId = Mockito.mock(ExpressionColumn.class);
+        ordersCustomerId = Mockito.mock(ExpressionColumn.class);
+        Mockito.when(ordersOrderId.getTableName()).thenReturn("orders");
+        Mockito.when(ordersLocationId.getTableName()).thenReturn("orders");
+        Mockito.when(ordersCustomerId.getTableName()).thenReturn("orders");
+        // order_lines (5,000)
+        //  -> order_id
+        //  -> location_id
+        //  -> customer_id
+        orderLinesOrderLineId = Mockito.mock(ExpressionColumn.class);
+        orderLinesOrderId = Mockito.mock(ExpressionColumn.class);
+        orderLinesLocationId = Mockito.mock(ExpressionColumn.class);
+        orderLinesCustomerId = Mockito.mock(ExpressionColumn.class);
+        Mockito.when(orderLinesOrderLineId.getTableName()).thenReturn("orderLines");
+        Mockito.when(orderLinesOrderId.getTableName()).thenReturn("orderLines");
+        Mockito.when(orderLinesLocationId.getTableName()).thenReturn("orderLines");
+        Mockito.when(orderLinesCustomerId.getTableName()).thenReturn("orderLines");
+    }
+
+    @Test
+    public void bestOrder_singleTable(){
+        TableFilter tableFilter = new TableFilter(mockSession, customersTable, "customers", true, null, 0, null);
+        tableFilter.setFullCondition(null);
+
+        List<TableFilter> expectedFilters = List.of(tableFilter);
+        TableFilter[] inputFilters = {tableFilter};
+
+        ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(mockSession, inputFilters);
+        List<TableFilter> result = Arrays.asList(ruleBasedJoinOrderPicker.bestOrder());
+
+        assertEquals(expectedFilters, result);
+    }
+
+    @Test
+    public void bestOrder_twoTablesSingleJoin(){
+        Expression locationsAndCustomers = new Comparison(
+                Comparison.EQUAL,
+                locationsLocationId,
+                customersLocationId,
+                false);
+
+        Expression fullCondition = new ConditionAndOrN(ConditionAndOr.AND,
+                List.of(
+                        locationsAndCustomers
+                )
+        );
+
+        TableFilter locationsFilter = new TableFilter(mockSession, locationsTable, "locations", true, null, 0, null);
+        locationsFilter.setFullCondition(fullCondition);
+
+        TableFilter customersFilter = new TableFilter(mockSession, customersTable, "customers", true, null, 0, null);
+        customersFilter.setFullCondition(fullCondition);
+
+        // locations is smaller so should go first
+        List<TableFilter> expectedFilters = List.of(locationsFilter, customersFilter);
+
+        TableFilter[] inputFilters = {customersFilter, locationsFilter};
+
+        ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(mockSession, inputFilters);
+        List<TableFilter> result = Arrays.asList(ruleBasedJoinOrderPicker.bestOrder());
+
+        assertEquals(expectedFilters, result);
+    }
+
+    @Test
+    public void bestOrder_threeTablesMultipleJoins(){
+        Expression fullCondition = new ConditionAndOrN(ConditionAndOr.AND,
+                List.of(
+                        new Comparison(Comparison.EQUAL, locationsLocationId, customersLocationId, false),
+                        new Comparison(Comparison.EQUAL, locationsLocationId, ordersLocationId, false),
+                        new Comparison(Comparison.EQUAL, customersCustomerId, ordersCustomerId, false)
+                )
+        );
+
+        TableFilter locationsFilter = new TableFilter(mockSession, locationsTable, "locations", true, null, 0, null);
+        locationsFilter.setFullCondition(fullCondition);
+
+        TableFilter customersFilter = new TableFilter(mockSession, customersTable, "customers", true, null, 0, null);
+        customersFilter.setFullCondition(fullCondition);
+
+        TableFilter ordersFilter = new TableFilter(mockSession, ordersTable, "orders", true, null, 0, null);
+        customersFilter.setFullCondition(fullCondition);
+
+        // size order is locations, customers, orders
+        List<TableFilter> expectedFilters = List.of(locationsFilter, customersFilter, ordersFilter);
+
+        TableFilter[] inputFilters = {customersFilter, ordersFilter, locationsFilter};
+
+        ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(mockSession, inputFilters);
+        List<TableFilter> result = Arrays.asList(ruleBasedJoinOrderPicker.bestOrder());
+
+        assertEquals(expectedFilters, result);
+    }
+
+    @Test
+    public void bestOrder_fourTablesMultipleJoins(){
+        Expression fullCondition = new ConditionAndOrN(ConditionAndOr.AND,
+                List.of(
+                        new Comparison(Comparison.EQUAL, locationsLocationId, customersLocationId, false),
+                        new Comparison(Comparison.EQUAL, locationsLocationId, ordersLocationId, false),
+                        new Comparison(Comparison.EQUAL, customersCustomerId, ordersCustomerId, false),
+                        new Comparison(Comparison.EQUAL, orderLinesLocationId, locationsLocationId, false),
+                        new Comparison(Comparison.EQUAL, orderLinesOrderId, ordersOrderId, false),
+                        new Comparison(Comparison.EQUAL, orderLinesCustomerId, customersCustomerId, false)
+                )
+        );
+
+        TableFilter locationsFilter = new TableFilter(mockSession, locationsTable, "locations", true, null, 0, null);
+        locationsFilter.setFullCondition(fullCondition);
+
+        TableFilter customersFilter = new TableFilter(mockSession, customersTable, "customers", true, null, 0, null);
+        customersFilter.setFullCondition(fullCondition);
+
+        TableFilter ordersFilter = new TableFilter(mockSession, ordersTable, "orders", true, null, 0, null);
+        ordersFilter.setFullCondition(fullCondition);
+
+        TableFilter orderLinesFilter = new TableFilter(mockSession, orderLinesTable, "orderLines", true, null, 0, null);
+        orderLinesFilter.setFullCondition(fullCondition);
+
+        // size order is locations, customers, orders, orderLines
+        List<TableFilter> expectedFilters = List.of(locationsFilter, customersFilter, ordersFilter, orderLinesFilter);
+
+        TableFilter[] inputFilters = {orderLinesFilter, customersFilter, ordersFilter, locationsFilter};
+
+        ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(mockSession, inputFilters);
+        List<TableFilter> result = Arrays.asList(ruleBasedJoinOrderPicker.bestOrder());
+
+        assertEquals(expectedFilters, result);
+    }
+}


### PR DESCRIPTION
## Query from HW 4 Problem 4 
 
![hw4](https://github.com/user-attachments/assets/ce1c69c3-384d-4f4f-b09f-a1a0d7d75a18)

I’m satisfied that the EXPLAIN ANALYZE output confirms my code changes. The plan shows a join order that avoids cartesian products and picks the table with the fewest rows first（POSTS(scanCount: 995087)->FOLLOWERS(scanCount: 99296828)->USERS(scanCount: 196603484)）, which matches the rules I implemented in RuleBasedJoinOrderPicker.
 
## HW 5 : Query 1 - Single Table
 
![hw5q1](https://github.com/user-attachments/assets/76c95334-f667-4b19-b385-9346fc07ebd5)

I’m satisfied that this single-table query confirms our code changes have not regressed the most basic query execution functionality. The EXPLAIN ANALYZE output shows a simple table scan on CUSTOMERS.
 
## HW 5 : Query 2 - Just Two Tables
 
![hw5q2](https://github.com/user-attachments/assets/60e7abf1-6c24-4b32-979d-95ecce53980c)
 
I’m satisfied that this two-table query still behaves correctly under our modifications. The plan shows a straightforward join on customers.customer_id = orders.customer_id, indicating no regressions in basic join functionality.
 
## HW 5 : Query 3 - Three Tables
 
![hw5q3](https://github.com/user-attachments/assets/b23b081e-4319-41fa-92a8-dc9439162208)

I’m satisfied that the plan first chooses PRODUCTS (the smallest table), then ORDER_DETAILS, and finally ORDERS, which aligns with our rule-based approach (avoiding cartesian products and picking the smallest table first). The EXPLAIN ANALYZE output confirms these changes are functioning correctly.
 
## HW 5 : Query 4 - Four Tables
 
![hw5q4](https://github.com/user-attachments/assets/53168277-a25d-411e-bacf-a05309044b91)

I’m satisfied that the EXPLAIN ANALYZE output follows the expected rule-based order—starting with CUSTOMERS (the smallest table), then ORDERS, then ORDER_DETAILS, and finally PRODUCTS. Each join uses an explicit ON clause, so no cartesian product occurs. 

## HW 5 : Query 5 - Five Tables
 
![hw5q5](https://github.com/user-attachments/assets/8178fffc-f33f-46b0-b99a-08bc83f3a7c6)
 
It appears the plan does not match the expected CUSTOMERS -> ORDERS -> ORDER_DETAILS -> PRODUCTS -> SUPPLIERS sequence. Instead, H2 starts withORDER_DETAILS, then moves to PRODUCTS, SUPPLIERS, ORDERS, and finally CUSTOMERS.
 
## HW 5 : Query 6 - Four Tables, More Options
 
![hw5q6](https://github.com/user-attachments/assets/45c31df8-6645-42fa-9459-97c5501bc185)
 
It looks like H2 is starting with ORDER_DETAILS (scanCount: 501), then ORDER_PAYMENTS (900), then PRODUCTS (800), and finally ORDERS, which does not match the expected PRODUCTS -> ORDER_DETAILS -> ORDER_PAYMENTS -> ORDER.
 
## Our rule based optimizer is still fairly limited.  Can you think of a query in which it would perform a fairly catastrophic join order?
 
Let's imagine a query joining a small Countries table (10 rows), a moderate Users table (1,000 rows), and two huge tables—Transactions and Logs (both with millions of rows). If our rule-based optimizer always starts with the smallest table and proceeds in that fixed manner, it might end up joining Transactions and Logs late, missing an early, highly selective filter on Logs. As a result, it would process millions of rows unnecessarily, leading to a catastrophic plan.
 
## Our rule based optimizer is still fairly limited.  If you were to improve it, what additional rules would you include?
 
I would add rules that account for filter selectivity and index availability. 
 